### PR TITLE
macOS user friendly tweaks

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -27,7 +27,7 @@ jobs:
         runtime: [linux-x64]
         include:
           - runtime: linux-x64
-            artifact_path: ./bin/Gtk/Release/net6.0/linux-x64
+            artifact_path: ./bin/Gtk/Release/net8.0/linux-x64
             self_contained: "--self-contained"
 
     runs-on: ubuntu-latest
@@ -38,11 +38,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8
         
     - name: Build for ${{ matrix.runtime }}
       run: |
-        dotnet build OpenTrace.csproj --runtime ${{ matrix.runtime }} --configuration Release ${{ matrix.self_contained }} -f net6.0
+        dotnet build OpenTrace.csproj --runtime ${{ matrix.runtime }} --configuration Release ${{ matrix.self_contained }} -f net8.0
 
     - name: Make tarball
       run: cd ${{ matrix.artifact_path }} && chmod +x ./OpenTrace && tar -cvzf ../${{ matrix.runtime }}.tar.gz ./
@@ -52,5 +52,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.runtime }}.tar.gz
-        path: ./bin/Gtk/Release/net6.0/${{ matrix.runtime }}.tar.gz
+        path: ./bin/Gtk/Release/net8.0/${{ matrix.runtime }}.tar.gz
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,17 +35,17 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8
         
     - name: Build for ${{ matrix.runtime }}
       run: |
-        dotnet build OpenTrace.csproj --runtime ${{ matrix.runtime }} --configuration Release --self-contained -f net6.0
+        dotnet build OpenTrace.csproj --runtime ${{ matrix.runtime }} --configuration Release --self-contained -f net8.0
 
     - name: Make tarball
-      run: cd ./bin/Mac64/Release/net6.0/${{ matrix.runtime }} && tar -cvzf OpenTrace_${{ matrix.runtime }}.app.tar.gz OpenTrace.app
+      run: cd ./bin/Mac64/Release/net8.0/${{ matrix.runtime }} && tar -cvzf OpenTrace_${{ matrix.runtime }}.app.tar.gz OpenTrace.app
       
     - name: Upload artifact for ${{ matrix.runtime }}
       uses: actions/upload-artifact@v3
       with:
         name: OpenTrace_${{ matrix.runtime }}.app.tar.gz
-        path: ./bin/Mac64/Release/net6.0/${{ matrix.runtime }}/OpenTrace_${{ matrix.runtime }}.app.tar.gz
+        path: ./bin/Mac64/Release/net8.0/${{ matrix.runtime }}/OpenTrace_${{ matrix.runtime }}.app.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,17 +23,17 @@ jobs:
             archive_command: "zip -r"
             archive_extension: zip
           - runtime: linux-x64
-            artifact_path: ./bin/Gtk/Release/net6.0/linux-x64
+            artifact_path: ./bin/Gtk/Release/net8.0/linux-x64
             self_contained: "--self-contained"
-            framework: net6.0
+            framework: net8.0
             nt_file: nexttrace_linux_amd64
             nt_fn: nexttrace
             archive_command: "tar -cvzf"
             archive_extension: tar.gz
           - runtime: osx-x64
-            artifact_path: ./bin/Mac64/Release/net6.0/osx-x64
+            artifact_path: ./bin/Mac64/Release/net8.0/osx-x64
             self_contained: "--self-contained"
-            framework: net6.0
+            framework: net8.0
             nt_file: nexttrace_darwin_amd64
             nt_fn: OpenTrace.app/Contents/MacOS/nexttrace
             pack_target: OpenTrace.app
@@ -49,7 +49,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6
+        dotnet-version: 8
 
     - name: Build
       run: dotnet build OpenTrace.csproj --runtime ${{ matrix.runtime }} --configuration Release ${{ matrix.self_contained }} -f ${{ matrix.framework }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8
         
     - name: Build for ${{ matrix.runtime }}
       run: |

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -191,8 +191,8 @@ namespace OpenTrace
                 ResetMap();
             };
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && UserSettings.hideAddICMPFirewallRule != true) tryAddICMPFirewallRule();
-
+            platformChecks();
+            
             // 绑定窗口事件
             SizeChanged += MainForm_SizeChanged;
             MouseDown += Dragging_MouseDown;
@@ -261,6 +261,21 @@ namespace OpenTrace
             dnsResolverSelection.SelectedIndex = 0;
         }
 
+        // 初始化期间进行平台特定检查
+        private void platformChecks()
+        {
+            
+            // macOS 被隔离，请求释放
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && AppDomain.CurrentDomain.BaseDirectory.StartsWith("/private/var/folders"))
+            {
+                App.app.Invoke(() => {
+                    MessageBox.Show(Resources.MACOS_QUARANTINE);
+                });
+            }
+            
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && UserSettings.hideAddICMPFirewallRule != true) tryAddICMPFirewallRule();
+        }
+        
         private void tryAddICMPFirewallRule()
         {
             // 提示 Windows 用户添加防火墙规则放行 ICMP 

--- a/OpenTrace.csproj
+++ b/OpenTrace.csproj
@@ -7,7 +7,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFrameworks>;net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>;net48;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <OutputType>Exe</OutputType>
     <PackageProjectUrl>https://github.com/Archeb/opentrace</PackageProjectUrl>

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,12 @@ using OpenTrace.Properties;
 
 namespace OpenTrace
 {
+    
+    class App 
+    {
+        public static Application app;
+    }
+
     internal class Program
     {
         [STAThread]
@@ -63,7 +69,8 @@ namespace OpenTrace
                 if (UserSettings.POWProvider == "" && UserSettings.POWProvider != null) UserSettings.POWProvider = "api.leo.moe";
             }
 
-            new Application(Eto.Platform.Detect).Run(new MainForm());
+            App.app = new Application(Eto.Platform.Detect);
+            App.app.Run(new MainForm());
         }
     }
 }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -646,6 +646,20 @@ namespace OpenTrace.Properties {
         }
         
         /// <summary>
+        ///   查找类似 OpenTrace is quarantined by macOS, something may be inoperative.
+        ///Please release OpenTrace as follows:
+        ///
+        ///sudo xattr -r -d com.apple.quarantine &lt;drag and drop OpenTrace here&gt;
+        ///
+        ///And restart OpenTrace after execution. 的本地化字符串。
+        /// </summary>
+        public static string MACOS_QUARANTINE {
+            get {
+                return ResourceManager.GetString("MACOS_QUARANTINE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Map Provider 的本地化字符串。
         /// </summary>
         public static string MAP_PROVIDER {
@@ -700,6 +714,20 @@ namespace OpenTrace.Properties {
         }
         
         /// <summary>
+        ///   查找类似 OpenTrace requires privileges to perform TCP/UDP trace.
+        ///Please set the permissions of NextTrace as follows:
+        ///
+        ///sudo xattr -r -d com.apple.quarantine /path/to/nexttrace
+        ///sudo chown root:admin /path/to/nexttrace
+        ///sudo chmod +sx /path/to/nexttrace 的本地化字符串。
+        /// </summary>
+        public static string MISSING_COMP_PRIV_MACOS {
+            get {
+                return ResourceManager.GetString("MISSING_COMP_PRIV_MACOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 OpenTrace requires the NextTrace utility to function properly. This executable is currently missing.
         ///NextTrace can be placed in either:
         ///1. The same directory as the OpenTrace executable
@@ -729,6 +757,15 @@ namespace OpenTrace.Properties {
         public static string MISSING_COMP_TEXT_MACOS {
             get {
                 return ResourceManager.GetString("MISSING_COMP_TEXT_MACOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 OpenTrace requires privileges to perform TCP/UDP trace 的本地化字符串。
+        /// </summary>
+        public static string MISSING_PRIV_MACOS {
+            get {
+                return ResourceManager.GetString("MISSING_PRIV_MACOS", resourceCulture);
             }
         }
         

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -344,6 +344,17 @@ And specify the path in the settings.
 
 Would you like to download the NextTrace utility now?</value>
   </data>
+  <data name="MISSING_COMP_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace requires privileges to perform TCP/UDP trace.
+Please set the permissions of NextTrace as follows:
+
+sudo xattr -r -d com.apple.quarantine /path/to/nexttrace
+sudo chown root:admin /path/to/nexttrace
+sudo chmod +sx /path/to/nexttrace</value>
+  </data>
+  <data name="MISSING_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace requires privileges to perform TCP/UDP trace</value>
+  </data>
   <data name="MISSING_SPECIFIED_COMP" xml:space="preserve">
     <value>NextTrace could not be found in "{0}".</value>
   </data>
@@ -460,5 +471,13 @@ To use an offline database, please refer to the NextTrace documentation to set i
   </data>
   <data name="WORST" xml:space="preserve">
     <value>Worst</value>
+  </data>
+  <data name="MACOS_QUARANTINE" xml:space="preserve">
+    <value>OpenTrace is quarantined by macOS, something may be inoperative.
+Please release OpenTrace as follows:
+
+sudo xattr -r -d com.apple.quarantine &lt;drag and drop OpenTrace here&gt;
+
+And restart OpenTrace after execution.</value>
   </data>
 </root>

--- a/Properties/Resources.zh-CN.resx
+++ b/Properties/Resources.zh-CN.resx
@@ -341,6 +341,17 @@ sudo chmod +sx /path/to/nexttrace
 
 是否现在下载 NextTrace？</value>
   </data>
+  <data name="MISSING_COMP_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要权限才能进行 TCP/UDP 追踪。
+请为 NextTrace 设置权限:
+
+sudo xattr -r -d com.apple.quarantine /path/to/nexttrace
+sudo chown root:admin /path/to/nexttrace
+sudo chmod +sx /path/to/nexttrace</value>
+  </data>
+  <data name="MISSING_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要权限才能进行 TCP/UDP 追踪</value>
+  </data>
   <data name="MISSING_SPECIFIED_COMP" xml:space="preserve">
     <value>未能在指定的位置 "{0}" 中找到 NextTrace。</value>
   </data>
@@ -455,5 +466,13 @@ sudo chmod +sx /path/to/nexttrace
   </data>
   <data name="WORST" xml:space="preserve">
     <value>最大延迟</value>
+  </data>
+  <data name="MACOS_QUARANTINE" xml:space="preserve">
+    <value>OpenTrace 被 macOS 隔离，工作可能不完全正常。
+请打开终端，使用下面的命令释放 OpenTrace:
+
+sudo xattr -r -d com.apple.quarantine &lt;将 OpenTrace 拖放至此&gt;
+
+并在完成释放后重启 OpenTrace.</value>
   </data>
 </root>

--- a/Properties/Resources.zh-HK.resx
+++ b/Properties/Resources.zh-HK.resx
@@ -301,6 +301,14 @@
   <data name="LOSS" xml:space="preserve">
     <value>丟包率%</value>
   </data>
+  <data name="MACOS_QUARANTINE" xml:space="preserve">
+    <value>OpenTrace 被 macOS 隔離，工作可能不完全正常。
+請打開終端，使用下面的命令釋放 OpenTrace:
+
+sudo xattr -r -d com.apple.quarantine &lt;將 OpenTrace 拖放至此&gt;
+
+並在完成釋放後重啓 OpenTrace.</value>
+  </data>
   <data name="MAP_PROVIDER" xml:space="preserve">
     <value>地圖數據源</value>
   </data>
@@ -318,6 +326,14 @@
   </data>
   <data name="MISSING_COMP" xml:space="preserve">
     <value>組件缺失</value>
+  </data>
+  <data name="MISSING_COMP_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要權限才能進行 TCP/UDP 追蹤。
+請為 NextTrace 設置權限:
+
+sudo xattr -r -d com.apple.quarantine /path/to/nexttrace
+sudo chown root:admin /path/to/nexttrace
+sudo chmod +sx /path/to/nexttrace</value>
   </data>
   <data name="MISSING_COMP_TEXT" xml:space="preserve">
     <value>OpenTrace 需要 NextTrace 才能正常工作，但未能找到可執行文件。
@@ -339,6 +355,9 @@ sudo chmod +sx /path/to/nexttrace
 然後在設置中指定 NextTrace 路徑。
 
 是否現在下載 NextTrace？</value>
+  </data>
+  <data name="MISSING_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要權限才能進行 TCP/UDP 追蹤</value>
   </data>
   <data name="MISSING_SPECIFIED_COMP" xml:space="preserve">
     <value>未能在指定的位置 "{0}" 中找到 NextTrace。</value>

--- a/Properties/Resources.zh-TW.resx
+++ b/Properties/Resources.zh-TW.resx
@@ -301,6 +301,14 @@
   <data name="LOSS" xml:space="preserve">
     <value>丟包率%</value>
   </data>
+  <data name="MACOS_QUARANTINE" xml:space="preserve">
+    <value>OpenTrace 被 macOS 隔離，工作可能不完全正常。
+請開啟終端，使用下面的命令釋放 OpenTrace:
+
+sudo xattr -r -d com.apple.quarantine &lt;將 OpenTrace 拖放至此&gt;
+
+並在完成釋放後重啟 OpenTrace.</value>
+  </data>
   <data name="MAP_PROVIDER" xml:space="preserve">
     <value>地圖資料來源</value>
   </data>
@@ -318,6 +326,14 @@
   </data>
   <data name="MISSING_COMP" xml:space="preserve">
     <value>元件缺失</value>
+  </data>
+  <data name="MISSING_COMP_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要權限才能進行 TCP/UDP 追蹤。
+請為 NextTrace 設置權限:
+
+sudo xattr -r -d com.apple.quarantine /path/to/nexttrace
+sudo chown root:admin /path/to/nexttrace
+sudo chmod +sx /path/to/nexttrace</value>
   </data>
   <data name="MISSING_COMP_TEXT" xml:space="preserve">
     <value>OpenTrace 需要 NextTrace 才能正常工作，但未能找到可執行檔案。
@@ -339,6 +355,9 @@ sudo chmod +sx /path/to/nexttrace
 然後在設定中指定 NextTrace 路徑。
 
 是否現在下載 NextTrace？</value>
+  </data>
+  <data name="MISSING_PRIV_MACOS" xml:space="preserve">
+    <value>OpenTrace 需要權限才能進行 TCP/UDP 追蹤</value>
   </data>
   <data name="MISSING_SPECIFIED_COMP" xml:space="preserve">
     <value>未能在指定的位置 "{0}" 中找到 NextTrace。</value>


### PR DESCRIPTION
## What's new

- [x] 引导解除隔离，以避免例如无法保存历史和配置的问题
- [x] 在需要 TCP/UDP 时自动为内置 nexttrace 设置 setuid，为外部 nexttrace 提供引导
- [x] 正确地为 macOS 加载 locale，避免 dotnet 搞出来 `en-CN` 的整蛊行为

## What's next

 - [ ] 完善英文语法
 - [ ] (maybe) 单独整一个被 setuid 的程序负责 nexttrace wrapper，缩小安全隐患维度

这应当有助于解决类似 #33 的问题。